### PR TITLE
fix mappool auto advancing on bans

### DIFF
--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -289,16 +289,15 @@ namespace osu.Game.Tournament.Screens.MapPool
                 BeatmapID = beatmapId
             });
 
-            setNextMode();
-
-            if (LadderInfo.AutoProgressScreens.Value)
+            if (LadderInfo.AutoProgressScreens.Value && pickType == ChoiceType.Pick)
             {
-                if (pickType == ChoiceType.Pick && CurrentMatch.Value.PicksBans.Any(i => i.Type == ChoiceType.Pick))
-                {
-                    scheduledScreenChange?.Cancel();
-                    scheduledScreenChange = Scheduler.AddDelayed(() => { sceneManager?.SetScreen(typeof(GameplayScreen)); }, 10000);
-                }
+                scheduledScreenChange?.Cancel();
+                scheduledScreenChange = Scheduler.AddDelayed(
+                    () => sceneManager?.SetScreen(typeof(GameplayScreen)),
+                    10000);
             }
+
+            setNextMode();
         }
 
         public override void Hide()


### PR DESCRIPTION
the mappool should never transition from mappool to gameplay if the last event was not a pick (e.g. ban or protect)